### PR TITLE
Update build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,7 @@
     //
     // It is redundant to include "zig" in this name because it is already
     // within the Zig package namespace.
-    .name = .sdl3,
+    .name = "sdl3",
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.


### PR DESCRIPTION
Changed the package name to a string literal, else using zig fetch <url> will result in "error: expected string literal.name = .sdl3,"